### PR TITLE
add -gml suffix to project name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "jiwer"
-version = "4.0.0"
+name = "jiwer-gml"
+version = "4.0.1"
 description = "Evaluate your speech-to-text system with similarity measures such as word error rate (WER)"
 readme = "README.md"
 authors = [
@@ -33,6 +33,11 @@ docs = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/jiwer"]
+# Map src directory to the root so imports work correctly
+sources = { "src" = "" }
 
 [tool.ruff.lint.isort]
 lines-between-types = 1


### PR DESCRIPTION
This PR is meant to build a `jiwer==4.0.1` that introduces `jiwer.visualize_error_counts()`, a utility function for WER results analysis. The current PyPi released version is `jiwer==3.1.0`. We'll switch to using it instead of our custom build once the `jiwer` package will be built and published by maintainers to PyPi.